### PR TITLE
Add miz_cotroller test

### DIFF
--- a/tests/util/CMakeLists.txt
+++ b/tests/util/CMakeLists.txt
@@ -5,3 +5,15 @@ add_library(mizcore::test_util ALIAS mizcore_test_util)
 target_link_libraries(mizcore_test_util PUBLIC nlohmann_json::nlohmann_json)
 target_include_directories(mizcore_test_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(mizcore_test_util PRIVATE cxx_std_17)
+
+add_test(
+  NAME mizcore_util_test
+  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/mizcore_util_test.out
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data/)
+
+add_executable(mizcore_util_test.out miz_controller_test.cpp main.cpp)
+
+target_link_libraries(
+  mizcore_util_test.out PRIVATE doctest::doctest mizcore::scanner
+                                  mizcore::parser mizcore::util mizcore::test_util)
+target_compile_features(mizcore_util_test.out PRIVATE cxx_std_17)

--- a/tests/util/data/numerals.miz
+++ b/tests/util/data/numerals.miz
@@ -1,0 +1,43 @@
+:: Numerals - Requirements
+::  by Library Committee
+::
+:: Received February 27, 2003
+:: Copyright (c) 2003-2021 Association of Mizar Users
+::           (Stowarzyszenie Uzytkownikow Mizara, Bialystok, Poland).
+:: This code can be distributed under the GNU General Public Licence
+:: version 3.0 or later, or the Creative Commons Attribution-ShareAlike
+:: License version 3.0 or later, subject to the binding interpretation
+:: detailed in file COPYING.interpretation.
+:: See COPYING.GPL and COPYING.CC-BY-SA for the full text of these
+:: licenses, or see http://www.gnu.org/licenses/gpl.html and
+:: http://creativecommons.org/licenses/by-sa/3.0/.
+
+environ
+
+ vocabularies XBOOLE_0, SUBSET_1, ORDINAL1;
+ notations XBOOLE_0, SUBSET_1, ORDINAL1;
+ constructors SUBSET_1, ORDINAL1;
+ requirements BOOLE;
+ theorems SUBSET_1, ORDINAL1;
+
+begin
+
+:: This file contains statements which are obvious for Mizar checker if
+:: "requirements NUMERALS" is included in the environment description
+:: of an article. They are published for testing purposes only.
+:: Users should use appropriate requirements instead of referencing
+:: to these theorems.
+:: Some of these items need also other requirements for proper work.
+:: Statements which cannot be expressed in Mizar language are commented out.
+
+theorem
+  {} is Element of omega
+proof
+  {} in omega by ORDINAL1:def 11;
+  hence thesis by SUBSET_1:def 1;
+end;
+ 
+::theorem
+::  numeral(X) implies X is Element of omega;
+::theorem
+::  numeral(X) implies succ(X) = X + 1;

--- a/tests/util/expected/numerals_blocks.json
+++ b/tests/util/expected/numerals_blocks.json
@@ -1,0 +1,195 @@
+{
+  "children": [
+    {
+      "pos": [
+        15,
+        1
+      ],
+      "statement_type": "environ",
+      "token_id": 13,
+      "type": "statement"
+    },
+    {
+      "pos": [
+        [
+          17,
+          2
+        ],
+        [
+          17,
+          43
+        ]
+      ],
+      "statement_type": "vocabularies",
+      "token_id": [
+        14,
+        20
+      ],
+      "type": "statement"
+    },
+    {
+      "pos": [
+        [
+          18,
+          2
+        ],
+        [
+          18,
+          40
+        ]
+      ],
+      "statement_type": "notations",
+      "token_id": [
+        21,
+        27
+      ],
+      "type": "statement"
+    },
+    {
+      "pos": [
+        [
+          19,
+          2
+        ],
+        [
+          19,
+          33
+        ]
+      ],
+      "statement_type": "constructors",
+      "token_id": [
+        28,
+        32
+      ],
+      "type": "statement"
+    },
+    {
+      "pos": [
+        [
+          20,
+          2
+        ],
+        [
+          20,
+          20
+        ]
+      ],
+      "statement_type": "requirements",
+      "token_id": [
+        33,
+        35
+      ],
+      "type": "statement"
+    },
+    {
+      "pos": [
+        [
+          21,
+          2
+        ],
+        [
+          21,
+          29
+        ]
+      ],
+      "statement_type": "theorems",
+      "token_id": [
+        36,
+        40
+      ],
+      "type": "statement"
+    },
+    {
+      "pos": [
+        23,
+        1
+      ],
+      "statement_type": "section",
+      "token_id": 41,
+      "type": "statement"
+    },
+    {
+      "pos": [
+        [
+          33,
+          1
+        ],
+        [
+          34,
+          20
+        ]
+      ],
+      "statement_type": "theorem",
+      "token_id": [
+        49,
+        54
+      ],
+      "type": "statement"
+    },
+    {
+      "children": [
+        {
+          "pos": [
+            [
+              36,
+              3
+            ],
+            [
+              36,
+              33
+            ]
+          ],
+          "statement_type": "unknown",
+          "token_id": [
+            56,
+            64
+          ],
+          "type": "statement"
+        },
+        {
+          "pos": [
+            [
+              37,
+              3
+            ],
+            [
+              37,
+              33
+            ]
+          ],
+          "statement_type": "hence",
+          "token_id": [
+            65,
+            72
+          ],
+          "type": "statement"
+        }
+      ],
+      "pos": [
+        [
+          35,
+          1
+        ],
+        [
+          38,
+          1
+        ]
+      ],
+      "token_id": [
+        55,
+        73
+      ],
+      "type": "block"
+    },
+    {
+      "pos": [
+        38,
+        4
+      ],
+      "statement_type": "empty",
+      "token_id": 74,
+      "type": "statement"
+    }
+  ],
+  "type": "block"
+}

--- a/tests/util/main.cpp
+++ b/tests/util/main.cpp
@@ -1,0 +1,2 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest/doctest.h"

--- a/tests/util/miz_controller_test.cpp
+++ b/tests/util/miz_controller_test.cpp
@@ -1,0 +1,51 @@
+#include <filesystem>
+#include <iostream>
+
+#include "ast_block.hpp"
+#include "doctest/doctest.h"
+#include "file_handling_tools.hpp"
+#include "miz_controller.hpp"
+
+using mizcore::MizController;
+namespace fs = std::filesystem;
+
+namespace {
+
+const fs::path&
+TEST_DIR()
+{
+    static fs::path test_dir = fs::path(__FILE__).parent_path();
+    return test_dir;
+}
+
+} // namespace
+
+TEST_CASE("test miz_controller")
+{
+    mizcore::MizController miz_controller;
+    auto mizpath = TEST_DIR() / "data" / "numerals.miz";
+    miz_controller.Exec(mizpath.c_str());
+
+    if (!fs::exists(TEST_DIR() / "result")) {
+        fs::create_directory(TEST_DIR() / "result");
+    }
+    fs::path result_file_path = TEST_DIR() / "result" / "numerals_blocks.json";
+    nlohmann::json json;
+    auto ast_root = miz_controller.GetASTRoot();
+    ast_root->ToJson(json);
+    mizcore::write_json_file(json, result_file_path);
+    fs::path expected_file_path =
+      TEST_DIR() / "expected" / "numerals_blocks.json";
+
+    auto json_diff =
+      mizcore::json_file_diff(result_file_path, expected_file_path);
+
+    CHECK(json_diff.empty());
+    if (!json_diff.empty()) {
+        fs::path diff_file_path =
+          TEST_DIR() / "result" / "numerals_blocks_diff.json";
+        mizcore::write_json_file(json_diff, diff_file_path);
+    } else {
+        remove(result_file_path.c_str());
+    }
+}


### PR DESCRIPTION
- miz_cotrollerのテストコードを追加しました
- テストの内容は[miz_block_parser_test](https://github.com/mimosa-project/mizcore/blob/4d825bb4794a9c865bc18a3897f7d9b0a5435075/tests/parser/miz_block_parser_test.cpp)と同様です.
  