### PR TITLE
Cross compile for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ cd build
 cmake ..
 make
 ```
-
+### Cross compile for windows
+```bash
+docker build -t llvm-mingw ./x86_64-w64-mingw/
+docker run -it --rm -v $(pwd):/mizcore llvm-mingw sh /mizcore/x86_64-w64-mingw/build.sh
+```
+Note: You need to put `libc++.dll`, `libunwind.dll` in the same directory as the executable. Refer to `/x86_64-w64-mingw/build.sh`
 ## Test
 
 ```bash

--- a/src/component/ast_type.hpp
+++ b/src/component/ast_type.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "ast_type.hpp"
 #include <memory>
+#include <string_view>
 
 namespace mizcore {
 

--- a/tests/parser/miz_block_parser_test.cpp
+++ b/tests/parser/miz_block_parser_test.cpp
@@ -94,7 +94,7 @@ TEST_CASE("execute miz file handler")
               TEST_DIR() / "result" / "numerals_blocks_diff.json";
             mizcore::write_json_file(json_diff, diff_file_path);
         } else {
-            remove(result_file_path.c_str());
+            remove(result_file_path.string().c_str());
         }
     }
 
@@ -143,7 +143,7 @@ TEST_CASE("execute miz file handler")
               TEST_DIR() / "result" / "jgraph_4_blocks_diff.json";
             mizcore::write_json_file(json_diff, diff_file_path);
         } else {
-            remove(result_file_path.c_str());
+            remove(result_file_path.string().c_str());
         }
     }
 }

--- a/tests/scanner/miz_lexer_handler_test.cpp
+++ b/tests/scanner/miz_lexer_handler_test.cpp
@@ -90,7 +90,7 @@ TEST_CASE("execute miz file handler")
               TEST_DIR() / "result" / "numerals_tokens_diff.json";
             mizcore::write_json_file(json_diff, diff_file_path);
         } else {
-            remove(result_file_path.c_str());
+            remove(result_file_path.string().c_str());
         }
     }
 
@@ -135,7 +135,7 @@ TEST_CASE("execute miz file handler")
               TEST_DIR() / "result" / "jgraph_4_tokens_diff.json";
             mizcore::write_json_file(json_diff, diff_file_path);
         } else {
-            remove(result_file_path.c_str());
+            remove(result_file_path.string().c_str());
         }
     }
 }

--- a/tests/util/miz_controller_test.cpp
+++ b/tests/util/miz_controller_test.cpp
@@ -24,7 +24,7 @@ TEST_CASE("test miz_controller")
 {
     mizcore::MizController miz_controller;
     auto mizpath = TEST_DIR() / "data" / "numerals.miz";
-    miz_controller.Exec(mizpath.c_str());
+    miz_controller.Exec(mizpath.string().c_str());
 
     if (!fs::exists(TEST_DIR() / "result")) {
         fs::create_directory(TEST_DIR() / "result");
@@ -46,6 +46,6 @@ TEST_CASE("test miz_controller")
           TEST_DIR() / "result" / "numerals_blocks_diff.json";
         mizcore::write_json_file(json_diff, diff_file_path);
     } else {
-        remove(result_file_path.c_str());
+        remove(result_file_path.string().c_str());
     }
 }

--- a/x86_64-w64-mingw/Dockerfile
+++ b/x86_64-w64-mingw/Dockerfile
@@ -1,0 +1,6 @@
+FROM mstorsjo/llvm-mingw
+
+RUN apt update && apt install -y flex bison
+
+RUN cp /usr/include/FlexLexer.h /opt/llvm-mingw/x86_64-w64-mingw32/include/
+RUN mkdir -p /mizcore/build

--- a/x86_64-w64-mingw/build.sh
+++ b/x86_64-w64-mingw/build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cmake -DCMAKE_TOOLCHAIN_FILE=/mizcore/x86_64-w64-mingw/x86_64-w64-mingw.cmake -B/mizcore/build/ /mizcore/
+cd /mizcore/build
+make
+
+cd /opt/llvm-mingw/x86_64-w64-mingw32/bin/
+cp libc++.dll libunwind.dll /mizcore/build/tests/parser
+cp libc++.dll libunwind.dll /mizcore/build/tests/scanner
+cp libc++.dll libunwind.dll /mizcore/build/tests/util

--- a/x86_64-w64-mingw/x86_64-w64-mingw.cmake
+++ b/x86_64-w64-mingw/x86_64-w64-mingw.cmake
@@ -1,0 +1,13 @@
+set(CMAKE_SYSTEM_NAME mingw)
+
+set(triple x86_64-w64-mingw32)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_FLAGS "-std=c++17 -stdlib=libc++ --rtlib=compiler-rt -fuse-ld=lld -unwindlib=libunwind -Qunused-arguments")
+
+set(CMAKE_SYSROOT /opt/llvm-mingw/x86_64-w64-mingw32)
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")


### PR DESCRIPTION
- x86_64-w64-mingw32へのクロスコンパイルを実行できるようにしました
  - https://github.com/mstorsjo/llvm-mingw を使用しました
  - コンパイルが通るようにソースコードの一部を修正しました
 ## 注意点
llvm-mingwでC++ コードをコンパイルしている場合, 実行時に以下のファイルを, 実行ファイルと同じディレクトリに置く必要があるそうです. (参考: https://qiita.com/syoyo/items/ce6829dd3841635d59b0)
  - libc++.dll
  - libunwind.dll
 
現時点で, 必要なディレクトリに上記のdllファイルをコピーする処理は`/x86_64-w64-mingw/build.sh`に書いています. 将来, 実行ファイルが追加された場合, ここに追加する必要があります
