### PR TITLE
Add scripts to cross-compile for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ docker build -t llvm-mingw ./x86_64-w64-mingw/
 docker run --rm -v $(pwd):/mizcore llvm-mingw sh /mizcore/x86_64-w64-mingw/build.sh
 ```
 Note: You need to put `libc++.dll`, `libunwind.dll` in the same directory as the executable. Refer to `/x86_64-w64-mingw/build.sh`
+### Cross compile for mac
+```bash
+docker build -t osxcross ./x86_64-apple-darwin/
+docker run --rm -v $(pwd):/mizcore osxcross sh /mizcore/x86_64-apple-darwin/build.sh
+```
 ## Test
 
 ```bash

--- a/x86_64-apple-darwin/Dockerfile
+++ b/x86_64-apple-darwin/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu
+
+RUN apt update && apt install -y wget xz-utils git patch python3 libssl-dev lzma-dev libxml2-dev clang cmake flex bison
+RUN git clone https://github.com/tpoechtrager/osxcross.git
+RUN wget -P /osxcross/tarballs https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz
+
+WORKDIR /osxcross
+RUN yes | ./build.sh
+ENV PATH $PATH:/osxcross/target/bin
+RUN cp /usr/include/FlexLexer.h /osxcross/target/SDK/MacOSX11.3.sdk/usr/include/

--- a/x86_64-apple-darwin/build.sh
+++ b/x86_64-apple-darwin/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+mkdir /mizcore/build
+cmake -DCMAKE_TOOLCHAIN_FILE=/mizcore/x86_64-apple-darwin/x86_64-apple-darwin.cmake -B/mizcore/build/ /mizcore/
+cd /mizcore/build
+make

--- a/x86_64-apple-darwin/x86_64-apple-darwin.cmake
+++ b/x86_64-apple-darwin/x86_64-apple-darwin.cmake
@@ -1,0 +1,8 @@
+set(CMAKE_SYSTEM_NAME darwin)
+
+set(CMAKE_C_COMPILER x86_64-apple-darwin20.4-clang)
+set(CMAKE_CXX_COMPILER x86_64-apple-darwin20.4-clang++)
+
+set(CMAKE_SYSROOT /osxcross/target/SDK/MacOSX11.3.sdk/)
+
+set(CMAKE_CXX_FLAGS "-std=c++17 -mmacosx-version-min=10.15")


### PR DESCRIPTION
- x86_64-w64-darwinへのクロスコンパイルを実行できるようにしました
- 以下のリポジトリを使用しました
  - https://github.com/tpoechtrager/osxcross
  - https://github.com/phracker/MacOSX-SDKs
