### PR TITLE
Fix segmentation errors when incorrect grammar was used

### DIFF
--- a/src/parser/miz_block_parser.cpp
+++ b/src/parser/miz_block_parser.cpp
@@ -59,6 +59,10 @@ MizBlockParser::Parse()
 {
     ASTToken* prev_token = nullptr;
     size_t token_num = token_table_->GetTokenNum();
+    if (token_num == 0) {
+        return;
+    }
+
     for (size_t i = 0; i < token_num; ++i) {
         auto* token = token_table_->GetToken(i);
         auto token_type = token->GetTokenType();
@@ -97,6 +101,8 @@ MizBlockParser::Parse()
         } else {
             RecordError(prev_token,
                         ERROR_TYPE::STATEMENT_NOT_CLOSED_IN_ARTICLE);
+            auto* last_token = token_table_->GetLastToken();
+            PopStatement(last_token);
         }
     }
 


### PR DESCRIPTION
ステートメントが正しく閉じられなかった場合(セミコロンがないとき)にセグメンテーションエラーが発生する問題の修正
最後のステートメントがセミコロンで終わっていない場合にPopStatementが呼ばれていなかった．